### PR TITLE
feat: allow use git commit id as version

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,7 +76,17 @@ async function installWindows(luaRocksVersion, tempBuildPath, luaRocksInstallPat
 }
 
 async function installUnix(luaRocksVersion, tempBuildPath, luaRocksInstallPath, luaPath) {
-  const sourceTar = await tc.downloadTool(`https://luarocks.org/releases/luarocks-${luaRocksVersion}.tar.gz`)
+  let sourceTar
+  if (luaRocksVersion.startsWith("@")) {
+    luaRocksVersion = luaRocksVersion.substring(1) // remove the '@' prefix
+    if (!luaRocksVersion) {
+      luaRocksVersion = "master" // default to master branch if no version is specified
+    }
+    sourceTar = await tc.downloadTool(`https://github.com/luarocks/luarocks/archive/${luaRocksVersion}.tar.gz`)
+  } else {
+    sourceTar = await tc.downloadTool(`https://luarocks.org/releases/luarocks-${luaRocksVersion}.tar.gz`)
+  }
+
   await tc.extractTar(sourceTar, path.join(tempBuildPath))
 
   const luaRocksExtractPath = path.join(tempBuildPath, `luarocks-${luaRocksVersion}`)


### PR DESCRIPTION
Currently this action only supports downloading source packages from `luarocks.org` in semver format.
In some cases, we need to allow it to use code from a specific git commit. For example, https://github.com/luarocks/luarocks/pull/1799

So this PR adds the precedent that when the version number starts with @ (e.g., `@12345678`), the subsequent string `12345678` will be treated as the git commit ID, which will cause the action to download the tgz from the GitHub archive.
If the version number is `@`, it means to use master branching, which is an easy way to do it.
I adopted this pattern from [hererocks](https://github.com/luarocks/hererocks?tab=readme-ov-file#version-selection), I didn't create it.