### PR TITLE
Prepare a new tag v7 that sets LuaRocks 3.13.0 as default version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.1.5", "5.2.4", "5.3.5", "5.4.8", "luajit", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4", "5.5"]
+        luaVersion: ["5.1.5", "5.2.4", "5.3.5", "5.4.8", "5.5.0", "luajit", "luajit-2.0.5", "luajit-2.1.0-beta3", "luajit-openresty", "5.1", "5.4", "5.5"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - uses: ilammy/msvc-dev-cmd@v1
+    - uses: step-security/msvc-dev-cmd@v1
       if: ${{ ! contains(matrix.luaVersion, 'luajit') }}
     - uses: luarocks/gh-actions-lua@master
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: luarocks/gh-actions-lua@master
       with:
         luaVersion: ${{ matrix.luaVersion }}
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: luarocks/gh-actions-lua@master
       with:
         luaVersion: "5.2"
@@ -61,7 +61,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: luarocks/gh-actions-lua@master
     - uses: ./
 
@@ -82,7 +82,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: step-security/msvc-dev-cmd@v1
       if: ${{ ! contains(matrix.luaVersion, 'luajit') }}
     - uses: luarocks/gh-actions-lua@master
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: leafo/gh-actions-openresty@main
     - uses: ./
       with:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For a more complete example see: https://github.com/luarocks/gh-actions-lua/blob
 
 ### `luaRocksVersion`
 
-**Default**: `"3.12.2"`
+**Default**: `"3.13.0"`
 
 Specifies which version of LuaRocks to install. Must be listed on https://luarocks.github.io/luarocks/releases/
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Builds and installs LuaRocks from source into the `.luarocks/` directory in the 
 Installs Lua, LuaRocks, then install a module:
 
 ```yaml
-- uses: luarocks/gh-actions-lua@v11
-- uses: luarocks/gh-actions-luarocks@v6
+- uses: luarocks/gh-actions-lua@v12
+- uses: luarocks/gh-actions-luarocks@v7
 
 # Install some package
 - name: install a module
@@ -34,7 +34,7 @@ Specifies which version of LuaRocks to install. Must be listed on https://luaroc
 Example:
 
 ```yaml
-- uses: luarocks/gh-actions-luarocks@v6
+- uses: luarocks/gh-actions-luarocks@v7
   with:
     luaRocksVersion: "3.1.3"
 ```
@@ -50,7 +50,7 @@ necessary if you are using `luarocks/gh-actions-lua`. Will build LuaRocks with
 Example:
 
 ```yaml
-- uses: luarocks/gh-actions-luarocks@v6
+- uses: luarocks/gh-actions-luarocks@v7
   with:
     withLuaPath: "/usr/local/openresty/luajit/"
 ```


### PR DESCRIPTION
## Description

CC @hishamhm

Lua 5.5 and LuaRocks 3.13.0 were updated 7 months ago, then I think it is a reasonable time to bump versions here.
Thus, there were minor changes preparing to push a new tag on both luarocks-gh-actions-* repos accounting for Lua 5.5 and LuaRocks 3.13.0.

## Changes

* Changes were mostly cosmetic;
* The only change worth to note was the move from [https://github.com/ilammy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd) to [https://github.com/step-security/msvc-dev-cmd](https://github.com/step-security/msvc-dev-cmd), following the upstream `leafo` action [https://github.com/leafo/gh-actions-lua](https://github.com/leafo/gh-actions-lua), due warnings regarding the use of EOL nodejs versions by ilammy.

> [!NOTE]
> 
> If there is no objection, I'll merge this PR and push a new tag tomorrow.